### PR TITLE
Fixes a validation issue with Google font links

### DIFF
--- a/docs/jeffbeam-resume.html
+++ b/docs/jeffbeam-resume.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Jeff Beam's resume</title>
-    <link href="https://fonts.googleapis.com/css?family=Merriweather|Open+Sans" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css" rel="stylesheet" />
     <style>
 


### PR DESCRIPTION
validator.nu says the pipe | character isn't allowed in the link href.